### PR TITLE
default email address for new users can be defined in settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,8 @@ Modify settings.py
     LOGOUT_URL='/your_url_extension/logout'
     LOGIN_REDIRECT_URL='/'
     LOGOUT_REDIRECT_URL='/'
+    
+    TWYTHON_DJANGO_DEFAULT_EMAIL = 'test@example.com'
 
 Need Twython Help?
 ------------------

--- a/twython_django_oauth/views.py
+++ b/twython_django_oauth/views.py
@@ -63,7 +63,7 @@ def thanks(request, redirect_url=settings.LOGIN_REDIRECT_URL):
         user = User.objects.get(username=authorized_tokens['screen_name'])
     except User.DoesNotExist:
         # We mock a creation here; no email, password is just the token, etc.
-        user = User.objects.create_user(authorized_tokens['screen_name'], "fjdsfn@jfndjfn.com", authorized_tokens['oauth_token_secret'])
+        user = User.objects.create_user(authorized_tokens['screen_name'], settings.TWYTHON_DJANGO_DEFAULT_EMAIL or "fjdsfn@jfndjfn.com", authorized_tokens['oauth_token_secret'])
         profile = TwitterProfile()
         profile.user = user
         profile.oauth_token = authorized_tokens['oauth_token']


### PR DESCRIPTION
default email address for new users can be defined in settings
TWYTHON_DJANGO_DEFAULT_EMAIL
