### PR TITLE
#17: Python3 and Django 3.1 migration

### DIFF
--- a/twython_django_oauth/models.py
+++ b/twython_django_oauth/models.py
@@ -10,6 +10,6 @@ class TwitterProfile(models.Model):
         oauth_secret in relation to a user. Adapt this if you have a current
         setup, there's really nothing special going on here.
     """
-    user = models.OneToOneField(User)
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
     oauth_token = models.CharField(max_length=200)
     oauth_secret = models.CharField(max_length=200)

--- a/twython_django_oauth/views.py
+++ b/twython_django_oauth/views.py
@@ -1,9 +1,9 @@
 from django.contrib.auth import authenticate, login, logout as django_logout
 from django.contrib.auth import get_user_model
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from twython import Twython
 
@@ -90,4 +90,4 @@ def user_timeline(request):
     twitter = Twython(settings.TWITTER_KEY, settings.TWITTER_SECRET,
                       user.oauth_token, user.oauth_secret)
     user_tweets = twitter.get_home_timeline()
-    return render_to_response('tweets.html', {'tweets': user_tweets})
+    return render(None, 'tweets.html', {'tweets': user_tweets})


### PR DESCRIPTION
Hi

Seems like there is on_delete field missing in twython_django_oauth/models.py:

```
  File "/home/brezerk/develop/example/.venv/lib/python3.6/site-packages/twython_django_oauth/models.py", line 5, in <module>
    class TwitterProfile(models.Model):
  File "/home/brezerk/develop/example/.venv/lib/python3.6/site-packages/twython_django_oauth/models.py", line 11, in TwitterProfile
    user = models.OneToOneField(User)
TypeError: __init__() missing 1 required positional argument: 'on_delete'
```

https://docs.djangoproject.com/en/3.1/ref/models/fields/#django.db.models.ForeignKey.on_delete

Addresses: https://github.com/ryanmcgrath/twython-django/issues/17